### PR TITLE
Export Data.Csv.HasHeader

### DIFF
--- a/src/System/IO/Streams/Csv.hs
+++ b/src/System/IO/Streams/Csv.hs
@@ -41,8 +41,15 @@ module System.IO.Streams.Csv
          -- ByteString@ stream into one that encodes records into CSV
          -- format before sending them downstream.
        , module System.IO.Streams.Csv.Encode
+
+         -- * Convenience Exports
+         -- | Export @HasHeader@ from cassava so we can use it without
+         -- importing Data.Csv
+       , module Data.Csv
        ) where
 
 --------------------------------------------------------------------------------
 import System.IO.Streams.Csv.Decode
 import System.IO.Streams.Csv.Encode
+
+import Data.Csv (HasHeader(..))

--- a/src/System/IO/Streams/Csv.hs
+++ b/src/System/IO/Streams/Csv.hs
@@ -43,8 +43,7 @@ module System.IO.Streams.Csv
        , module System.IO.Streams.Csv.Encode
 
          -- * Convenience Exports
-         -- | Export @HasHeader@ from cassava so we can use it without
-         -- importing Data.Csv
+         -- | Export data types from Data.Csv
        , module Data.Csv
        ) where
 
@@ -52,4 +51,10 @@ module System.IO.Streams.Csv
 import System.IO.Streams.Csv.Decode
 import System.IO.Streams.Csv.Encode
 
-import Data.Csv (HasHeader(..))
+import Data.Csv ( HasHeader(..)
+                , defaultEncodeOptions
+                , defaultDecodeOptions
+                , DecodeOptions(..)
+                , EncodeOptions(..)
+                , Quoting(..)
+                )


### PR DESCRIPTION
It would be convenient to be able to import just `System.IO.Streams.Csv` and be done with it, even when using the `-With` functions. This patch just reexports `HasHeader(..)`, `DecodeOptions(..)`, `EncodeOptions(..)`, `Quoting` and `defaultEncodeOptions`, `defaultDecodeOptions`.
